### PR TITLE
Added statsCompanionUpload boolean field to database

### DIFF
--- a/amplify/backend/api/ff6wcstats/schema.graphql
+++ b/amplify/backend/api/ff6wcstats/schema.graphql
@@ -60,6 +60,7 @@ type Run @model @auth(rules: [{ allow: public }]) {
   mood: Mood
   seed: String
   raceId: String
+  statsCompanionUpload: Boolean
 }
 
 type RunConnection {
@@ -103,6 +104,7 @@ type Mutation {
     mood: Mood
     seed: String
     raceId: String
+    statsCompanionUpload: Boolean
   ): String
 }
 

--- a/amplify/backend/function/submitRun/src/index.js
+++ b/amplify/backend/function/submitRun/src/index.js
@@ -98,6 +98,7 @@ async function createRun(run) {
       thiefReward: run.thiefReward,
       race: run.race,
       raceId: run.raceId,
+      statsCompanionUpload: run.statsCompanionUpload,
       mood: run.mood,
       seed: run.seed,
     },

--- a/amplify/backend/function/submitRun/src/validation.js
+++ b/amplify/backend/function/submitRun/src/validation.js
@@ -514,6 +514,20 @@ function validate_raceId(runData) {
   }
 }
 
+async function validate_statsCompanionUpload(runData) {
+  // Validates that statsCompanionUpload is a boolean
+  return typeof runData.statsCompanionUpload == "boolean"
+    ? {
+        result: true,
+      }
+    : {
+        result: false,
+        reason:
+          "Value must be true or false.  Users should never see this message. Please contact administrator.",
+      };
+  s;
+}
+
 function checkNumberRange(value, min, max) {
   if (value.length === 0) {
     return { result: false, reason: "No number submitted." };

--- a/src/components/Submit/Submit.jsx
+++ b/src/components/Submit/Submit.jsx
@@ -76,9 +76,9 @@ function submissionReducer(state, action) {
       return {
         hide_page: false,
         submit_modal: true,
-        file_upload: false,
-        file_upload_confirm_modal: false,
-        file_upload_error: false,
+        file_upload: state.file_upload,
+        file_upload_confirm_modal: state.file_upload_confirm_modal,
+        file_upload_error: state.file_upload_error,
         submitted: true,
         processed: false,
         verified: false,
@@ -89,9 +89,9 @@ function submissionReducer(state, action) {
       return {
         hide_page: false,
         submit_modal: false,
-        file_upload: false,
-        file_upload_confirm_modal: false,
-        file_upload_error: false,
+        file_upload: state.file_upload,
+        file_upload_confirm_modal: state.file_upload_confirm_modal,
+        file_upload_error: state.file_upload_error,
         submitted: true,
         processed: true,
         verified: action.submissionResults.validation.validationStatus,
@@ -179,6 +179,9 @@ function Submit(props) {
         submitPayload[key] = event.target[key].value;
       }
     });
+
+    // Set a flag that indicates whether the submission was manual or from StatsCompanion
+    submitPayload["statsCompanionUpload"] = submissionState.file_upload;
 
     // Send data to the backend and set the response to `submissionState.dataValidationResults`
     try {


### PR DESCRIPTION
## Submission Checklist

- [X] Have you run and tested the application locally?
- [X] If tested locally, did you test with an adaquete amount of sample data?
- [X] Did you run `pre-commit` or `task validate`?

## Changes
- Adding Statscompanion boolean to database.  This is set to `true` when a StatsCompanion file is uploaded in a submission and `false` when it is a manual submission
<!--
This section should contain a bullet point list of changes in your PR, ie:
- Change #1
- Change #2
--->

## Issues
- [Add "StatsCompanionUpload" boolean to database for Runs](https://trello.com/c/YWatSEJI/89-add-statscompanionupload-boolean-to-database-for-runs)
<!--
This section should contain any links to issues on Trello (see https://trello.com/b/nM7RaY0u/ff6wc-stats ) related to the changes, ie:
- [Issue #1](link_on_trello)
- [Issue #2](link_on_trello)
--->
