### PR TITLE
Adding whole StatsCompanion file Adding the entirety of the StatsCompanion file to the database as a stringified-JSON, to future-proof datato database

### DIFF
--- a/amplify/backend/api/ff6wcstats/schema.graphql
+++ b/amplify/backend/api/ff6wcstats/schema.graphql
@@ -61,6 +61,7 @@ type Run @model @auth(rules: [{ allow: public }]) {
   seed: String
   raceId: String
   statsCompanionUpload: Boolean
+  statsCompanionRaw: AWSJSON
 }
 
 type RunConnection {
@@ -105,6 +106,7 @@ type Mutation {
     seed: String
     raceId: String
     statsCompanionUpload: Boolean
+    statsCompanionRaw: AWSJSON
   ): String
 }
 

--- a/amplify/backend/function/submitRun/src/index.js
+++ b/amplify/backend/function/submitRun/src/index.js
@@ -99,6 +99,7 @@ async function createRun(run) {
       race: run.race,
       raceId: run.raceId,
       statsCompanionUpload: run.statsCompanionUpload,
+      statsCompanionRaw: JSON.stringify(run.statsCompanionRaw),
       mood: run.mood,
       seed: run.seed,
     },

--- a/amplify/backend/function/submitRun/src/validation.js
+++ b/amplify/backend/function/submitRun/src/validation.js
@@ -528,6 +528,32 @@ async function validate_statsCompanionUpload(runData) {
   s;
 }
 
+async function validate_statsCompanionRaw(runData) {
+  // Validates that statsCompanionRaw is a valid JSON
+  try {
+    var parsedJSON = JSON.parse(JSON.stringify(runData.statsCompanionRaw));
+
+    // Handle non-exception-throwing cases:
+    // Neither JSON.parse(false) or JSON.parse(1234) throw errors, hence the type-checking,
+    // but... JSON.parse(null) returns null, and typeof null === "object",
+    // so we must check for that, too. Thankfully, null is falsey, so this suffices:
+    if (parsedJSON && typeof parsedJSON === "object") {
+      return { result: true };
+    } else {
+      return {
+        result: false,
+        reason: "StatsCompanion file is not a valid JSON.",
+      };
+    }
+  } catch (e) {
+    console.error(e);
+    return {
+      result: false,
+      reason: e,
+    };
+  }
+}
+
 function checkNumberRange(value, min, max) {
   if (value.length === 0) {
     return { result: false, reason: "No number submitted." };

--- a/src/components/Submit/Submit.jsx
+++ b/src/components/Submit/Submit.jsx
@@ -162,7 +162,6 @@ function Submit(props) {
   const handleSubmit = (event) => {
     event.preventDefault();
 
-    console.log(props.config.submit);
     // Dynamically create the submission payload based on the config
     let submitPayload = { userId: props.discordUserdata.userdata.id };
     Object.keys(props.config.submit).forEach((key, index) => {
@@ -182,6 +181,11 @@ function Submit(props) {
 
     // Set a flag that indicates whether the submission was manual or from StatsCompanion
     submitPayload["statsCompanionUpload"] = submissionState.file_upload;
+
+    // If a StatsCompanion file was uploaded, save the file contents as `statsCompanionRaw`
+    submitPayload["statsCompanionRaw"] = JSON.stringify(
+      submitFieldData.statsCompanionRaw,
+    );
 
     // Send data to the backend and set the response to `submissionState.dataValidationResults`
     try {
@@ -212,6 +216,7 @@ function Submit(props) {
           props.config.submit,
           submitFieldData,
           setSubmissionState,
+          setSubmitFieldData,
         );
       } catch (err) {
         console.log("Error uploading StatsCompanion file");
@@ -530,6 +535,7 @@ function populateFieldsFromFile(
   config,
   submitFieldData,
   setSubmissionState,
+  setSubmitFieldData,
 ) {
   /**
    * Given a JSON file of submission data, re-render the form fields with
@@ -538,6 +544,7 @@ function populateFieldsFromFile(
    * @param {Object} config The config file for `submit` section of the statscollide config
    * @param {Object} submitFieldData The state for each submission field
    * @param {Function} setSubmissionState The mutator function for the submission page state
+   * @param {Function} setSubmitFieldData The mutator function for the submission field data
    */
 
   const submissionJSON = JSON.parse(fileContents);
@@ -565,6 +572,7 @@ function populateFieldsFromFile(
     }
   }
 
+  setSubmitFieldData({ ...submitFieldData, statsCompanionRaw: submissionJSON });
   setSubmissionState({ type: "file_upload" });
 }
 

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -34,6 +34,7 @@ export const submitRun = /* GraphQL */ `
     $seed: String
     $raceId: String
     $statsCompanionUpload: Boolean
+    $statsCompanionRaw: AWSJSON
   ) {
     submitRun(
       runTime: $runTime
@@ -67,6 +68,7 @@ export const submitRun = /* GraphQL */ `
       seed: $seed
       raceId: $raceId
       statsCompanionUpload: $statsCompanionUpload
+      statsCompanionRaw: $statsCompanionRaw
     )
   }
 `;
@@ -119,6 +121,7 @@ export const createUser = /* GraphQL */ `
           seed
           raceId
           statsCompanionUpload
+          statsCompanionRaw
           createdAt
           updatedAt
           __typename
@@ -182,6 +185,7 @@ export const updateUser = /* GraphQL */ `
           seed
           raceId
           statsCompanionUpload
+          statsCompanionRaw
           createdAt
           updatedAt
           __typename
@@ -245,6 +249,7 @@ export const deleteUser = /* GraphQL */ `
           seed
           raceId
           statsCompanionUpload
+          statsCompanionRaw
           createdAt
           updatedAt
           __typename
@@ -316,6 +321,7 @@ export const createRun = /* GraphQL */ `
       seed
       raceId
       statsCompanionUpload
+      statsCompanionRaw
       createdAt
       updatedAt
       __typename
@@ -379,6 +385,7 @@ export const updateRun = /* GraphQL */ `
       seed
       raceId
       statsCompanionUpload
+      statsCompanionRaw
       createdAt
       updatedAt
       __typename
@@ -442,6 +449,7 @@ export const deleteRun = /* GraphQL */ `
       seed
       raceId
       statsCompanionUpload
+      statsCompanionRaw
       createdAt
       updatedAt
       __typename

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -52,6 +52,7 @@ export const runsForUser = /* GraphQL */ `
         seed
         raceId
         statsCompanionUpload
+        statsCompanionRaw
         createdAt
         updatedAt
         __typename
@@ -107,6 +108,7 @@ export const getUser = /* GraphQL */ `
           seed
           raceId
           statsCompanionUpload
+          statsCompanionRaw
           createdAt
           updatedAt
           __typename
@@ -211,6 +213,7 @@ export const getRun = /* GraphQL */ `
       seed
       raceId
       statsCompanionUpload
+      statsCompanionRaw
       createdAt
       updatedAt
       __typename
@@ -272,6 +275,7 @@ export const listRuns = /* GraphQL */ `
         seed
         raceId
         statsCompanionUpload
+        statsCompanionRaw
         createdAt
         updatedAt
         __typename
@@ -346,6 +350,7 @@ export const RunsByTime = /* GraphQL */ `
         seed
         raceId
         statsCompanionUpload
+        statsCompanionRaw
         createdAt
         updatedAt
         __typename
@@ -420,6 +425,7 @@ export const RunsByAttempt = /* GraphQL */ `
         seed
         raceId
         statsCompanionUpload
+        statsCompanionRaw
         createdAt
         updatedAt
         __typename

--- a/src/graphql/subscriptions.js
+++ b/src/graphql/subscriptions.js
@@ -47,6 +47,7 @@ export const onCreateUser = /* GraphQL */ `
           seed
           raceId
           statsCompanionUpload
+          statsCompanionRaw
           createdAt
           updatedAt
           __typename
@@ -107,6 +108,7 @@ export const onUpdateUser = /* GraphQL */ `
           seed
           raceId
           statsCompanionUpload
+          statsCompanionRaw
           createdAt
           updatedAt
           __typename
@@ -167,6 +169,7 @@ export const onDeleteUser = /* GraphQL */ `
           seed
           raceId
           statsCompanionUpload
+          statsCompanionRaw
           createdAt
           updatedAt
           __typename
@@ -235,6 +238,7 @@ export const onCreateRun = /* GraphQL */ `
       seed
       raceId
       statsCompanionUpload
+      statsCompanionRaw
       createdAt
       updatedAt
       __typename
@@ -295,6 +299,7 @@ export const onUpdateRun = /* GraphQL */ `
       seed
       raceId
       statsCompanionUpload
+      statsCompanionRaw
       createdAt
       updatedAt
       __typename
@@ -355,6 +360,7 @@ export const onDeleteRun = /* GraphQL */ `
       seed
       raceId
       statsCompanionUpload
+      statsCompanionRaw
       createdAt
       updatedAt
       __typename


### PR DESCRIPTION
## Submission Checklist

- [X] Have you run and tested the application locally?
- [X] If tested locally, did you test with an adaquete amount of sample data?
- [X] Did you run `pre-commit` or `task validate`?

## Changes
- Adding the entirety of the StatsCompanion file to the database as a stringified-JSON, to future-proof data
<!--
This section should contain a bullet point list of changes in your PR, ie:
- Change #1
- Change #2
--->

## Issues
- [Add "StatsCompanionRaw" field to database for Runs](https://trello.com/c/tdaBtcvt/90-add-statscompanionraw-field-to-database-for-runs)
<!--
This section should contain any links to issues on Trello (see https://trello.com/b/nM7RaY0u/ff6wc-stats ) related to the changes, ie:
- [Issue #1](link_on_trello)
- [Issue #2](link_on_trello)
--->
