### PR TITLE
Fixing unneeded JSON verification for StatsCompanion

### DIFF
--- a/amplify/backend/function/submitRun/src/validation.js
+++ b/amplify/backend/function/submitRun/src/validation.js
@@ -562,6 +562,11 @@ async function validate_statsCompanionUpload(runData) {
 
 // eslint-disable-next-line no-unused-vars
 async function validate_statsCompanionRaw(runData) {
+  // If no StatsCompanion file is uploaded, skip this check
+  if (!runData.statsCompanionUpload) {
+    return { result: true };
+  }
+
   // Validates that statsCompanionRaw is a valid JSON
   try {
     var parsedJSON = JSON.parse(JSON.stringify(runData.statsCompanionRaw));


### PR DESCRIPTION
## Submission Checklist

- [X] Have you run and tested the application locally?
- [X] If tested locally, did you test with an adaquate amount of sample data?
- [X] Did you run `pre-commit` or `task validate`?

## Changes
- Adding a check to `validate_statsCompanionRaw` that checks if a StatsCompanion JSON was uploaded.  Without this, if a `null` was defaulted to `statsCompanionRaw` (which could happen if data was entered without StatsCompanion), the upload would fail.
<!--
This section should contain a bullet point list of changes in your PR, ie:
- Change #1
- Change #2
--->

## Issues
- N/A
<!--
This section should contain any links to issues on Trello (see https://trello.com/b/nM7RaY0u/ff6wc-stats ) related to the changes, ie:
- [Issue #1](link_on_trello)
- [Issue #2](link_on_trello)
--->
